### PR TITLE
[Feature] Reuse deprecated function as fallback

### DIFF
--- a/batchs/onoffmixEventNotifier.js
+++ b/batchs/onoffmixEventNotifier.js
@@ -20,6 +20,7 @@ module.exports = (function () {
 
   /**
    * 모임 정보 API를 호출하여 최신 등록된 모임 목록을 반환한다.
+   * @return {Array} 모임 목록
    */
   function requestEventInfo () {
     const url = _config.url
@@ -30,29 +31,28 @@ module.exports = (function () {
       }
     }
 
-    return new Promise((onFulfilled, onRejected) => {
-      axios.get(url, options)
-        .then((result) => {
-          let eventList = result.data.eventList.map((event) => {
-            return {
-              index: event.idx,
-              thumbnail: event.bannerUrl,
-              link: event.eventUrl,
-              title: event.title,
-              content: event.abstract.replace(/\r\n/g, ' '),
-              extractTime: taskTs,
-              source: _config.source
-            }
-          })
-
-          onFulfilled(eventList)
+    return axios
+      .get(url, options)
+      .then((result) => {
+        return result.data.eventList.map((event) => {
+          return {
+            index: event.idx,
+            thumbnail: event.bannerUrl,
+            link: event.eventUrl,
+            title: event.title,
+            content: event.abstract.replace(/\r\n/g, ' '),
+            extractTime: taskTs,
+            source: _config.source
+          }
         })
-    })
+      })
   }
 
   /**
    * 모임 정보 사이트를 크롤링하여 모임 목록을 반환한다.
-   * @deprecated requestApi() api 호출로 변경
+   * 본 펑션은 requestEventInfo 의 fallback function으로,
+   * 해당 펑션에서 오류가 발생 할 경우 호출된다.
+   * @return {Array} 모임 목록
    */
   function crawl () {
     return new Promise((onFulfilled, onRejected) => {
@@ -125,24 +125,28 @@ module.exports = (function () {
     loadUserInfo()
       .then((subscriberList) => {
         subscriberList.forEach((subscriber) => {
-          // 모임 제목 또는 내용이 사용자가 등록한 키워드에 해당할 경우 알림 대상으로 처리한다.
-          let subscribedEventList = eventList.filter((event) => {
-            return subscriber.regexp.test(event.title) || subscriber.regexp.test(event.content)
-          })
+          try {
+            // 모임 제목 또는 내용이 사용자가 등록한 키워드에 해당할 경우 알림 대상으로 처리한다.
+            let subscribedEventList = eventList.filter((event) => {
+              return subscriber.regexp.test(event.title) || subscriber.regexp.test(event.content)
+            })
 
-          if ( subscribedEventList.length > 0 ) {
-            // 사용자에게 발송될 메시지 본문을 생성한다.
-            // let messageHeader = `[${ts()}]`
-            let messageHeader = `${_config.source}\n새로운 모임을 발견했습니다.`
-            let messageBody = subscribedEventList.map(generateMessageBody).join('\n\n')
+            if ( subscribedEventList.length > 0 ) {
+              // 사용자에게 발송될 메시지 본문을 생성한다.
+              let messageHeader = `${_config.source}\n새로운 모임을 발견했습니다.`
+              let messageBody = subscribedEventList.map(generateMessageBody).join('\n\n')
 
-            // Markdown 형식으로 키워드를 강조한다.
-            let message = `${messageHeader}\n\n${messageBody}`
-              .replace(/[\*\[\]]/g, '') // preventing error
-              .replace(subscriber.regexp, '*$1*')
-            
-            // 텔레그램 봇을 통해 모임 안내 메시지를 발송한다.
-            bot.sendMessage(subscriber.id, message, { parse_mode: 'Markdown' })
+              // Markdown 형식으로 키워드를 강조한다.
+              let message = `${messageHeader}\n\n${messageBody}`
+                .replace(/[\*\[\]]/g, '') // preventing error
+                .replace(subscriber.regexp, '*$1*')
+              
+              // 텔레그램 봇을 통해 모임 안내 메시지를 발송한다.
+              bot.sendMessage(subscriber.id, message, { parse_mode: 'Markdown' })
+            }
+          } catch (error) {
+            // 각 안내 메시지 전송은 사용자 간 독립적으로 수행한다.
+            console.error(`[${_config.jobName}][${taskTs}] Error occured during sending message, user: ${subscriber.id}, error:`, error)
           }
         })
 
@@ -189,6 +193,7 @@ module.exports = (function () {
       console.log(`[${_config.jobName}][${taskTs}] Job has been started.`)
 
       requestEventInfo()
+        .catch(crawl)
         .then(postExtract)
         .then(notifyUser)
         .catch((error) => {

--- a/config.js.sample
+++ b/config.js.sample
@@ -11,8 +11,10 @@ module.exports = {
     jobName: '${string-job-name}',
     // 데이터 수집 원천 식별자 (알림 메시지 표기됨)
     source: '${string-source}'
-    // 데이터 수집 대상 url (온오프믹스)
+    // 데이터 수집 대상 url: 온오프믹스 - api
     url: '${string-url}',
+    // [optional] 데이터 수집 대상 url: 온오프믹스 - crawling
+    url_crawl: '${string-url}',
     // 텔레그램 봇 연동을 위한 token
     telegramBotToken: '${string-telegram-bot-token}'
   }


### PR DESCRIPTION
As we mentioned in #6, I migrated `crawl` function into `requestEventInfo`'s fallback.

This **fallback** called in following conditions:
- `Axios` request succeed: but has no event information (`response.data.eventList` prop)
- `Axios` request fail. (for more detailed implementaion, [axios official document](https://github.com/mzabriskie/axios#handling-errors) can be refered)