### PR TITLE
Merge from dev to master for deploy

### DIFF
--- a/batchs/onoffmixEventNotifier.js
+++ b/batchs/onoffmixEventNotifier.js
@@ -20,6 +20,7 @@ module.exports = (function () {
 
   /**
    * 모임 정보 API를 호출하여 최신 등록된 모임 목록을 반환한다.
+   * @return {Array} 모임 목록
    */
   function requestEventInfo () {
     const url = _config.url
@@ -30,29 +31,28 @@ module.exports = (function () {
       }
     }
 
-    return new Promise((onFulfilled, onRejected) => {
-      axios.get(url, options)
-        .then((result) => {
-          let eventList = result.data.eventList.map((event) => {
-            return {
-              index: event.idx,
-              thumbnail: event.bannerUrl,
-              link: event.eventUrl,
-              title: event.title,
-              content: event.abstract.replace(/\r\n/g, ' '),
-              extractTime: taskTs,
-              source: _config.source
-            }
-          })
-
-          onFulfilled(eventList)
+    return axios
+      .get(url, options)
+      .then((result) => {
+        return result.data.eventList.map((event) => {
+          return {
+            index: event.idx,
+            thumbnail: event.bannerUrl,
+            link: event.eventUrl,
+            title: event.title,
+            content: event.abstract.replace(/\r\n/g, ' '),
+            extractTime: taskTs,
+            source: _config.source
+          }
         })
-    })
+      })
   }
 
   /**
    * 모임 정보 사이트를 크롤링하여 모임 목록을 반환한다.
-   * @deprecated requestApi() api 호출로 변경
+   * 본 펑션은 requestEventInfo 의 fallback function으로,
+   * 해당 펑션에서 오류가 발생 할 경우 호출된다.
+   * @return {Array} 모임 목록
    */
   function crawl () {
     return new Promise((onFulfilled, onRejected) => {
@@ -125,24 +125,28 @@ module.exports = (function () {
     loadUserInfo()
       .then((subscriberList) => {
         subscriberList.forEach((subscriber) => {
-          // 모임 제목 또는 내용이 사용자가 등록한 키워드에 해당할 경우 알림 대상으로 처리한다.
-          let subscribedEventList = eventList.filter((event) => {
-            return subscriber.regexp.test(event.title) || subscriber.regexp.test(event.content)
-          })
+          try {
+            // 모임 제목 또는 내용이 사용자가 등록한 키워드에 해당할 경우 알림 대상으로 처리한다.
+            let subscribedEventList = eventList.filter((event) => {
+              return subscriber.regexp.test(event.title) || subscriber.regexp.test(event.content)
+            })
 
-          if ( subscribedEventList.length > 0 ) {
-            // 사용자에게 발송될 메시지 본문을 생성한다.
-            // let messageHeader = `[${ts()}]`
-            let messageHeader = `${_config.source}\n새로운 모임을 발견했습니다.`
-            let messageBody = subscribedEventList.map(generateMessageBody).join('\n\n')
+            if ( subscribedEventList.length > 0 ) {
+              // 사용자에게 발송될 메시지 본문을 생성한다.
+              let messageHeader = `${_config.source}\n새로운 모임을 발견했습니다.`
+              let messageBody = subscribedEventList.map(generateMessageBody).join('\n\n')
 
-            // Markdown 형식으로 키워드를 강조한다.
-            let message = `${messageHeader}\n\n${messageBody}`
-              .replace(/[\*\[\]]/g, '') // preventing error
-              .replace(subscriber.regexp, '*$1*')
-            
-            // 텔레그램 봇을 통해 모임 안내 메시지를 발송한다.
-            bot.sendMessage(subscriber.id, message, { parse_mode: 'Markdown' })
+              // Markdown 형식으로 키워드를 강조한다.
+              let message = `${messageHeader}\n\n${messageBody}`
+                .replace(/[\*\[\]]/g, '') // preventing error
+                .replace(subscriber.regexp, '*$1*')
+              
+              // 텔레그램 봇을 통해 모임 안내 메시지를 발송한다.
+              bot.sendMessage(subscriber.id, message, { parse_mode: 'Markdown' })
+            }
+          } catch (error) {
+            // 각 안내 메시지 전송은 사용자 간 독립적으로 수행한다.
+            console.error(`[${_config.jobName}][${taskTs}] Error occured during sending message, user: ${subscriber.id}, error:`, error)
           }
         })
 
@@ -189,6 +193,7 @@ module.exports = (function () {
       console.log(`[${_config.jobName}][${taskTs}] Job has been started.`)
 
       requestEventInfo()
+        .catch(crawl)
         .then(postExtract)
         .then(notifyUser)
         .catch((error) => {

--- a/config.js.sample
+++ b/config.js.sample
@@ -9,10 +9,10 @@ module.exports = {
   onoffmixEventNotifier: {
     // 배치 프로세스 구분을 위한 Name String
     jobName: '${string-job-name}',
-    // 크롤링 대상 url (온오프믹스)
+    // 데이터 수집 원천 식별자 (알림 메시지 표기됨)
+    source: '${string-source}'
+    // 데이터 수집 대상 url (온오프믹스)
     url: '${string-url}',
-    // 배치 작업 간격 (null일 경우 동적 간격을 적용합니다)
-    //fixedInterval: number-fixed-interval,
     // 텔레그램 봇 연동을 위한 token
     telegramBotToken: '${string-telegram-bot-token}'
   }

--- a/config.js.sample
+++ b/config.js.sample
@@ -11,8 +11,10 @@ module.exports = {
     jobName: '${string-job-name}',
     // 데이터 수집 원천 식별자 (알림 메시지 표기됨)
     source: '${string-source}'
-    // 데이터 수집 대상 url (온오프믹스)
+    // 데이터 수집 대상 url: 온오프믹스 - api
     url: '${string-url}',
+    // [optional] 데이터 수집 대상 url: 온오프믹스 - crawling
+    url_crawl: '${string-url}',
     // 텔레그램 봇 연동을 위한 token
     telegramBotToken: '${string-telegram-bot-token}'
   }

--- a/models/onoffmixEvent.js
+++ b/models/onoffmixEvent.js
@@ -5,6 +5,7 @@ const schema = new mongoose.Schema({
   thumbnail: String,
   link: String,
   title: String,
+  content: String,
   extractTime: String
 })
 


### PR DESCRIPTION
다음의  사항을 실제 배포 코드에 반영
- Resolves #3 with 	2204ec6
  - `title` 이 수정된 모임 정보의 경우 사용자에게 알림 재전송
  - 사용자 별 알림 대상 모임 정보인지 판단 할 때 `title` 외 `content` 도 추가로 체크
- Resolves #6 with #14 
  - 온오프믹스 API 호출 실패시 fallback 프로세스로 웹페이지를 크롤링하도록 변경
- 데이터 스키마 변경
  - `onoffmix.events` > `events`
  - `telegram.users` > `users`